### PR TITLE
Run cross compile on every push

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -51,8 +51,12 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.arch }}
       - name: Build target
         run: |
-          cargo install cross
-          cross build --release --verbose --target $ARCH
+          if [[ $OS =~ ^.*ubuntu.*$ ]]; then
+            cargo install cross
+            cross build --release --verbose --target $ARCH
+          elif [[ $OS =~ ^.*macos.*$ ]]; then
+            cargo build --release --verbose --target $ARCH
+          fi
 
       - name: Compress
         run: |

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -56,7 +56,8 @@ jobs:
           fi
       - name: Build target
         run: |
-          cargo build --release --verbose --target $ARCH
+          cargo install cross
+          cross build --release --verbose --target $ARCH
 
       - name: Compress
         run: |

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Build target
         run: |
           cargo install cross
+          cargo install cargo-edit
+          cargo set-version ${{ github.event.release.tag_name }}
           cross build --release --verbose --target $ARCH
 
       - name: Compress

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -49,11 +49,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-${{ matrix.arch }}
-      - name: Install dependencies
-        run: |
-          if [[ $OS =~ ^.*ubuntu.*$ ]]; then
-              sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf mingw-w64
-          fi
       - name: Build target
         run: |
           cargo install cross

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     name: binary release
+    env:
+      NAME: kitsuyui-rust-playground  # executable binary name
+      ARCH: ${{ matrix.arch }}
+      OS: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,10 +41,6 @@ jobs:
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
-    env:
-      NAME: kitsuyui-rust-playground  # executable binary name
-      ARCH: ${{ matrix.arch }}
-      OS: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -52,8 +52,6 @@ jobs:
       - name: Build target
         run: |
           cargo install cross
-          cargo install cargo-edit
-          cargo set-version ${{ github.event.release.tag_name }}
           cross build --release --verbose --target $ARCH
 
       - name: Compress

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,6 +1,7 @@
 name: binary release
 
 on:
+  push:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
@@ -73,7 +74,8 @@ jobs:
           mv ./target/$ARCH/release/$EXEC ./$EXEC
           tar -czf ./artifacts/$NAME-$ARCH-$TAG.tar.gz $EXEC
 
-      - name: Archive artifact
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: result

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: |
-          cargo install cargo-edit
-          cargo set-version ${{ github.event.release.tag_name }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --all-features
 


### PR DESCRIPTION
Currently, cross compile is only done at release.
It is better to guarantee that cross compile can be done every time you push to playground.
