### PR TITLE
Use resolver 2 in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ features = ["vendored"]
 
 [workspace]
 
+resolver = "2"
 members = [
     "c1",
     "c2",


### PR DESCRIPTION
Rust 1.51.0 allows to use resolver = "2".
edition = "2021" is implicitly set resolver = "2".
However, it is necessary to explicitly set it in the workspace.
