### PR TITLE
Update workflows to use v4 of actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -85,9 +85,9 @@ jobs:
           tar -czf ./artifacts/$NAME-$ARCH-$VERSION.tar.gz $EXECUTABLE
 
       - name: Archive artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binary-${{ env.VERSION }}
+          name: binary-${{ env.VERSION }}-${{ env.ARCH }}-${{ env.OS }}
           path: ./artifacts
           retention-days: 1
 
@@ -96,9 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: binary-${{ env.VERSION }}
+          pattern: binary-${{ env.VERSION }}-*
+          merge-multiple: true
           path: ./artifacts
 
       - name: List

--- a/.github/workflows/shared-library-release.yml
+++ b/.github/workflows/shared-library-release.yml
@@ -76,9 +76,9 @@ jobs:
           tar -czf ./artifacts/lib-$NAME-$ARCH-$VERSION.tar.gz $LIB
 
       - name: Archive artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: lib-${{ env.VERSION }}
+          name: lib-${{ env.VERSION }}-${{ env.OS }}-${{ env.ARCH }}
           path: ./artifacts
           retention-days: 1
 
@@ -87,9 +87,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: lib-${{ env.VERSION }}
+          pattern: lib-${{ env.VERSION }}-*
+          merge-multiple: true
           path: ./artifacts
 
       - name: List

--- a/.github/workflows/wasm-npm-publish.yml
+++ b/.github/workflows/wasm-npm-publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Create tarball
         run: tar -czf pkg.tar.gz pkg
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wasm-${{ env.VERSION }}
           path: ./wasm/pkg.tar.gz


### PR DESCRIPTION
This is a breaking change, we must to avoid conflicting the names of the artifacts
https://github.com/actions/download-artifact#breaking-changes
https://github.com/actions/upload-artifact#breaking-changes
