### PR TITLE
Update workflows to use v4 of actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -148,9 +148,9 @@ jobs:
           python -c 'from kitsuyui_rust_playground import my_calc; assert my_calc(1, 2, 3) == "9"; print("OK")'
           deactivate
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ env.VERSION }}
+          name: wheels-${{ env.VERSION }}-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.rust_target }}
           path: target/wheels/
           retention-days: 1
 
@@ -158,9 +158,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels-${{ env.VERSION }}
+          pattern: wheels-${{ env.VERSION }}-*
           path: target/wheels/
 
       - name: Publish distribution to GitHub Releases


### PR DESCRIPTION
This is a breaking change, we must to avoid conflicting the names of the artifacts
https://github.com/actions/download-artifact#breaking-changes
https://github.com/actions/upload-artifact#breaking-changes

PR continuation of #196
