### PR TITLE
Abstract implementation of Checkpoint and Snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsuyui-rust-playground-checkpoint"
+version = "0.1.8"
+
+[[package]]
 name = "kitsuyui-rust-playground-lib"
 version = "0.1.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ members = [
     "c2",
     "python",
     "wasm",
+    "checkpoint",
 ]
 
 default-members = [
     "c1",
     "c2",
+    "checkpoint",
 ]

--- a/checkpoint/Cargo.toml
+++ b/checkpoint/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kitsuyui-rust-playground-checkpoint"
+description = "Checkpoint and Snapshot"
+license = "MIT OR Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+
+crate-type = ["lib"]
+
+[dependencies]

--- a/checkpoint/README.md
+++ b/checkpoint/README.md
@@ -1,0 +1,1 @@
+# Checkpoint and Snapshot

--- a/checkpoint/src/id.rs
+++ b/checkpoint/src/id.rs
@@ -1,0 +1,50 @@
+use std::hash::Hash;
+
+// Id is a type that represents a unique identifier for a snapshot or checkpoint.
+// It must implement Eq, Hash, and Ord.
+pub trait Id: Sized + PartialEq + Eq + Hash + Copy + Clone + PartialOrd + Ord {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // test u64 as Id
+    #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
+    struct U64Id(u64);
+
+    impl Id for U64Id {}
+
+    #[test]
+    fn test_equality() {
+        let id1 = U64Id(1);
+        let id2 = U64Id(2);
+        let id3 = U64Id(3);
+
+        // test equality
+        assert_eq!(id1, id1);
+        assert_eq!(id2, id2);
+        assert_eq!(id3, id3);
+        assert_ne!(id1, id2);
+        assert_ne!(id1, id3);
+        assert_ne!(id2, id3);
+    }
+
+    #[test]
+    fn test_hashable() {
+        let id1 = U64Id(1);
+        let id2 = U64Id(2);
+        let id3 = U64Id(3);
+
+        // Id can be used as a key in a HashMap
+        let mut set = std::collections::HashSet::new();
+        set.insert(id1);
+        assert!(set.contains(&id1));
+        assert!(!set.contains(&id2));
+        assert!(!set.contains(&id3));
+
+        set.insert(id2);
+        assert!(set.contains(&id1));
+        assert!(set.contains(&id2));
+        assert!(!set.contains(&id3));
+    }
+}

--- a/checkpoint/src/lib.rs
+++ b/checkpoint/src/lib.rs
@@ -1,0 +1,72 @@
+mod id;
+use crate::id::Id;
+
+pub trait SnapshotRecord<CheckpointID: Id> {
+    fn id(&self) -> &CheckpointID;
+}
+
+pub trait CheckpointRecord<SnapshotID: Id, CheckpointID: Id> {
+    fn id(&self) -> &CheckpointID;
+    fn parent_ids(&self) -> Vec<&CheckpointID>;
+    fn snapshot_id(&self) -> &SnapshotID;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
+    struct U64Id(u64);
+
+    impl Id for U64Id {}
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct U64SnapshotRecord {
+        id: U64Id,
+    }
+
+    impl SnapshotRecord<U64Id> for U64SnapshotRecord {
+        fn id(&self) -> &U64Id {
+            &self.id
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct U64CheckpointRecord {
+        id: U64Id,
+        parent_ids: Vec<U64Id>,
+        snapshot_id: U64Id,
+    }
+
+    impl CheckpointRecord<U64Id, U64Id> for U64CheckpointRecord {
+        fn id(&self) -> &U64Id {
+            &self.id
+        }
+
+        fn parent_ids(&self) -> Vec<&U64Id> {
+            self.parent_ids.iter().collect()
+        }
+
+        fn snapshot_id(&self) -> &U64Id {
+            &self.snapshot_id
+        }
+    }
+
+    #[test]
+    fn test_basis() {
+        let snapshot_id = U64Id(1);
+        let snapshot = U64SnapshotRecord { id: snapshot_id };
+        assert_eq!(snapshot.id(), &snapshot_id);
+
+        let checkpoint_id = U64Id(2);
+        let checkpoint = U64CheckpointRecord {
+            id: checkpoint_id,
+            parent_ids: vec![U64Id(1)],
+            snapshot_id: U64Id(1),
+        };
+
+        assert_eq!(checkpoint.id(), &checkpoint_id);
+        assert_eq!(checkpoint.parent_ids(), vec![&U64Id(1)]);
+        assert_eq!(checkpoint.snapshot_id(), &U64Id(1));
+    }
+}


### PR DESCRIPTION
Implement abstract Checkpoint and Snapshot concepts like Git's commit and object.
It does not depend on actual primitive types, including Id.
