### PR TITLE
Update to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "0.1.8"
-edition = "2021"
+edition = "2024"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kitsuyui/rust-playground"


### PR DESCRIPTION
- Rust edition 2024 has been released.
https://rust-lang.github.io/rfcs/3501-edition-2024.html

- But nothing has changed in the code, so no need to update the code in this
  repository.
