### PR TITLE
Tighten Ruff lint rules for Python package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,3 +51,29 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "D", "S101"]

--- a/python/pysrc/kitsuyui_rust_playground/__init__.py
+++ b/python/pysrc/kitsuyui_rust_playground/__init__.py
@@ -1,6 +1,5 @@
-import kitsuyui_rust_playground._native as _native  # type: ignore  # noqa: F403
+import kitsuyui_rust_playground._native as _native  # type: ignore
 from kitsuyui_rust_playground._native import *  # noqa: F403
-
 
 if hasattr(_native, "__doc__"):
     __doc__ = _native.__doc__


### PR DESCRIPTION
## Summary

- tighten the Ruff configuration for the Python package with a stricter non-formatter-conflicting rule set
- clean up import ordering and remove an obsolete `noqa` while keeping test pragmatism

## Verification

- `cd python && uv run --with ruff --with mypy --with pytest --with maturin --with poethepoet poe check-all`
- `cd python && uv run --with ruff --with mypy --with pytest --with pytest-cov --with maturin --with poethepoet poe test`
