### PR TITLE
Add actionlint check for release workflows

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -20,7 +20,6 @@ jobs:
       OS: ${{ matrix.os }}
       PACKAGE: ${{ matrix.package }}
       GCC: ${{ matrix.gcc }}
-      CFLAGS: ${{ matrix.cflags }}
       EXECUTABLE: kitsuyui-rust-playground${{ matrix.arch == 'x86_64-pc-windows-gnu' && '.exe' || '' }}
     strategy:
       fail-fast: false
@@ -60,16 +59,16 @@ jobs:
 
       - name: Install APT packages
         if: (matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-22.04') && matrix.package != ''
-        run: sudo apt-get update && sudo apt-get install -y $PACKAGE
+        run: sudo apt-get update && sudo apt-get install -y "$PACKAGE"
 
       - name: Build target
-        run: cargo build --release --verbose --target $ARCH
+        run: cargo build --release --verbose --target "$ARCH"
 
       - name: Compress
         run: |
           mkdir -p ./artifacts
-          mv ./target/$ARCH/release/$EXECUTABLE ./$EXECUTABLE
-          tar -czf ./artifacts/$NAME-$ARCH-$VERSION.tar.gz $EXECUTABLE
+          mv "./target/$ARCH/release/$EXECUTABLE" "./$EXECUTABLE"
+          tar -czf "./artifacts/$NAME-$ARCH-$VERSION.tar.gz" "$EXECUTABLE"
 
       - name: Archive artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/shared-library-release.yml
+++ b/.github/workflows/shared-library-release.yml
@@ -20,7 +20,6 @@ jobs:
       OS: ${{ matrix.os }}
       PACKAGE: ${{ matrix.package }}
       GCC: ${{ matrix.gcc }}
-      CFLAGS: ${{ matrix.cflags }}
       LIB: ${{
         matrix.arch == 'x86_64-pc-windows-gnu' && 'kitsuyui_rust_playground_lib.dll' ||
         matrix.os == 'macos-latest' && 'libkitsuyui_rust_playground_lib.dylib' ||
@@ -63,17 +62,17 @@ jobs:
 
       - name: Install APT packages
         if: matrix.os == 'ubuntu-latest' && matrix.package != ''
-        run: sudo apt-get update && sudo apt-get install -y $PACKAGE
+        run: sudo apt-get update && sudo apt-get install -y "$PACKAGE"
 
       - name: Build target
-        run: cargo build --release --verbose --target $ARCH
+        run: cargo build --release --verbose --target "$ARCH"
 
       - name: Compress
         run: |
           mkdir -p ./artifacts
           find ./target/
-          mv ./target/$ARCH/release/$LIB ./$LIB
-          tar -czf ./artifacts/lib-$NAME-$ARCH-$VERSION.tar.gz $LIB
+          mv "./target/$ARCH/release/$LIB" "./$LIB"
+          tar -czf "./artifacts/lib-$NAME-$ARCH-$VERSION.tar.gz" "$LIB"
 
       - name: Archive artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,16 @@ on:
     branches:
       - main
 jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -70,4 +80,3 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - run: cargo llvm-cov --lcov --output-path coverage.lcov
-


### PR DESCRIPTION
## Summary

- Remove stale CFLAGS matrix references from release workflows now that musl targets are gone.
- Quote release workflow shell variables so Actionlint can lint the shell fragments cleanly.
- Add an Actionlint job to the existing test workflow.

## Tests

- `actionlint .github/workflows/*.yml`
- `cargo fmt --all -- --check`
- `git diff --check`
