### PR TITLE
Use reusable maintenance workflows

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -11,21 +11,4 @@ permissions:
 
 jobs:
   gh-counter:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Count type-ignore markers
-        uses: kitsuyui/gh-counter@v1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload gh-counter output
-        uses: actions/upload-artifact@v4
-        with:
-          name: gh-counter-output
-          path: .gh-counter
-          include-hidden-files: true
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@main

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -10,10 +10,4 @@ permissions:
 
 jobs:
   happy:
-    runs-on: ubuntu-latest
-    name: happy
-    continue-on-error: true
-    steps:
-      - uses: kitsuyui/happy-commit@v0.9
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,7 @@ on:
       - main
 jobs:
   actionlint:
-    name: Actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-      - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
-
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
   check:
     name: Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace direct maintenance action invocations with reusable workflows from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific triggers and permissions in the caller workflows.
- Split embedded spellcheck steps into a reusable spellcheck job where needed.

## Verification
- Parsed the changed workflow YAML files.
- Ran `actionlint` on the changed workflow files.
