### PR TITLE
Pin reusable workflow references

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   gh-counter:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@0b691527a4dde052c79eae22706131a7726a2bba

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@0b691527a4dde052c79eae22706131a7726a2bba


### PR DESCRIPTION
## Summary
- pin reusable workflow calls to the current `kitsuyui/gh-actions-workflows` commit
- keep the existing triggers and token permissions unchanged

## Verification
- `actionlint .github/workflows/gh-counter.yml .github/workflows/happy.yml`
- `git diff --check`
- `cargo check --workspace`
