### PR TITLE
Pin remaining external action refs to SHA

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -74,7 +74,7 @@ jobs:
           tar -czf "./artifacts/$NAME-$ARCH-$VERSION.tar.gz" "$EXECUTABLE"
 
       - name: Archive artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: binary-${{ env.VERSION }}-${{ env.ARCH }}-${{ env.OS }}
           path: ./artifacts
@@ -87,7 +87,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: binary-${{ env.VERSION }}-*
           merge-multiple: true
@@ -98,6 +98,6 @@ jobs:
 
       - name: Release
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: ./artifacts/*.tar.gz

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -28,7 +28,7 @@ jobs:
 
       # For incremental builds
       - name: git-restore-mtime
-        uses: chetan/git-restore-mtime-action@v2.3
+        uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
 
       - uses: actions/cache@v5
         with:
@@ -47,7 +47,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 


### PR DESCRIPTION
## Summary

Replace mutable `@v6` / `@v7` / `@v2` / `@v2.3` / `@v1` references with
40-char commit SHAs (and keep the original tag as a trailing comment).

The reusable workflow references in `gh-counter.yml`, `happy.yml`, and
`gitignore-in.yml` are already SHA-pinned; this PR brings the remaining
external actions in `binary-release.yml`, `octocov.yml`, and
`pypi-publish.yml` to the same style.

## Pinned references

| Reference | Pinned SHA | Workflow |
| --- | --- | --- |
| `actions/upload-artifact@v6` | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` | `binary-release.yml` |
| `actions/download-artifact@v7` | `37930b1c2abaa49bbe596cd826c3c89aef350131` | `binary-release.yml` |
| `softprops/action-gh-release@v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | `binary-release.yml` |
| `chetan/git-restore-mtime-action@v2.3` | `d186aca54f8760da4dec55313195e51ed3ebb0b3` | `octocov.yml` |
| `k1LoW/octocov-action@v1` | `b3b6ee60482a667950f87553abf1df63217235d9` | `octocov.yml` |
| `actions/setup-python@v6` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | `pypi-publish.yml` |

Renovate (`helpers:pinGitHubActionDigests`) will keep these digests
updated going forward.

## Test plan

- [x] `actionlint` reports no issues on the three changed workflows
- [ ] CI test workflow passes
- [ ] CI octocov workflow passes