### PR TITLE
Rename SnapshotRecord type parameter

### DIFF
--- a/checkpoint/src/lib.rs
+++ b/checkpoint/src/lib.rs
@@ -1,8 +1,8 @@
 mod id;
 use crate::id::Id;
 
-pub trait SnapshotRecord<CheckpointID: Id> {
-    fn id(&self) -> &CheckpointID;
+pub trait SnapshotRecord<SnapshotID: Id> {
+    fn id(&self) -> &SnapshotID;
 }
 
 pub trait CheckpointRecord<SnapshotID: Id, CheckpointID: Id> {


### PR DESCRIPTION
## Summary

Rename the `SnapshotRecord` type parameter from `CheckpointID` to `SnapshotID`.

## Changes

- Update `checkpoint/src/lib.rs` so the public trait signature matches the identifier role it represents.
- Leave `CheckpointRecord<SnapshotID, CheckpointID>` unchanged, preserving the existing distinction between snapshot and checkpoint IDs.

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `actionlint`
- `cargo doc --no-deps`
- `git diff --check`

## Notes

This is an API documentation/readability fix for the generic parameter name only. Runtime behavior is unchanged.
