### PR TITLE
Return greeting string from greet() instead of calling alert()

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,11 +1,6 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern "C" {
-    pub fn alert(s: &str);
-}
-
-#[wasm_bindgen]
-pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!", name));
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
 }


### PR DESCRIPTION
## Summary

`greet(name: &str)` in `wasm/src/lib.rs` called `window.alert()` as an implicit side effect. The function signature returned `()` with no indication that it would block the browser event loop until the user dismissed a modal dialog. Callers expecting lightweight logging-style behavior would get a blocking UI interaction instead.

## Changes

- **`wasm/src/lib.rs`**: change `greet()` to return `String` (`format!("Hello, {}!", name)`) instead of calling `alert()`. Remove the now-unused `alert` extern binding.

The function behavior is now fully expressed by its return type. Callers that want to display the greeting in a dialog can call `alert()` themselves explicitly.

## Verification

- `cargo clippy`: clean (no warnings)
- `cargo test`: all tests pass
- `cargo fmt --check`: no changes needed
