### PR TITLE
Add structured logging redaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +658,8 @@ dependencies = [
  "reqwest",
  "ring",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -666,6 +677,12 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -705,6 +722,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1074,6 +1100,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,7 +1652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1601,6 +1674,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1638,6 +1741,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ hex = "0.4.3"
 tokio = { version = "1.37.0", features= ["full"] }
 pyo3 = { version = "0.28.0", features = ["extension-module"] }
 pyo3-build-config = "0.28.0"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [workspace.dependencies.openssl]
 version = "0.10.64"

--- a/c1/Cargo.toml
+++ b/c1/Cargo.toml
@@ -14,3 +14,5 @@ ring.workspace = true
 hex.workspace = true
 tokio.workspace = true
 openssl.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/c1/src/main.rs
+++ b/c1/src/main.rs
@@ -1,23 +1,36 @@
+use reqwest::header::{HeaderMap, HeaderName};
+use tracing::{debug, error, info};
+use tracing_subscriber::EnvFilter;
+
 fn main() {
+    init_tracing();
     show_openssl_version();
     request_to_example_com();
     let digest = get_digest();
-    println!("Digest: {digest}");
+    info!(digest, "computed digest");
     match tokio::runtime::Runtime::new() {
         Ok(rt) => {
             if let Err(err) = rt.block_on(tokio_example()) {
-                println!("Error: {err}");
+                error!(%err, "tokio example failed");
             }
         }
         Err(err) => {
-            println!("Error: {err}");
+            error!(%err, "failed to create tokio runtime");
         }
     }
 }
 
+fn init_tracing() {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .init();
+}
+
 fn show_openssl_version() {
     let version = openssl::version::version();
-    println!("OpenSSL version: {version}");
+    info!(version, "detected OpenSSL version");
 }
 
 fn get_digest() -> String {
@@ -27,7 +40,7 @@ fn get_digest() -> String {
 }
 
 async fn tokio_example() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Hello, World!");
+    info!("hello from async example");
     Ok(())
 }
 
@@ -35,21 +48,51 @@ fn request_to_example_com() {
     let client = reqwest::blocking::Client::new();
     match client.get("https://example.com").send() {
         Ok(res) => {
-            println!("Status: {}", res.status());
-            println!("Headers:\n{:#?}", res.headers());
+            info!(status = %res.status(), "received response");
+            debug!(headers = ?redacted_headers(res.headers()), "received response headers");
             match res.text() {
                 Ok(body) => {
-                    println!("Body:\n{body}");
+                    debug!(body_bytes = body.len(), "received response body");
                 }
                 Err(err) => {
-                    println!("Error: {err}");
+                    error!(%err, "failed to read response body");
                 }
             }
         }
         Err(err) => {
-            println!("Error: {err}");
+            error!(%err, "request failed");
         }
     }
+}
+
+fn redacted_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let value = if is_sensitive_header(name) {
+                "<redacted>".to_owned()
+            } else {
+                value
+                    .to_str()
+                    .map_or_else(|_| "<non-utf8>".to_owned(), str::to_owned)
+            };
+            (name.as_str().to_owned(), value)
+        })
+        .collect()
+}
+
+fn is_sensitive_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "authorization"
+            | "cookie"
+            | "set-cookie"
+            | "proxy-authorization"
+            | "x-api-key"
+            | "x-auth-token"
+            | "access-token"
+            | "refresh-token"
+    )
 }
 
 #[cfg(test)]
@@ -72,5 +115,29 @@ mod tests {
         let expected_hex = "09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b";
         let actual = get_digest();
         assert_eq!(expected_hex, actual);
+    }
+
+    #[test]
+    fn redacts_sensitive_header_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer secret".parse().unwrap());
+        headers.insert("content-type", "text/html".parse().unwrap());
+
+        let redacted = redacted_headers(&headers);
+
+        assert_eq!(
+            redacted
+                .iter()
+                .find(|(name, _)| name == "authorization")
+                .map(|(_, value)| value),
+            Some(&"<redacted>".to_owned())
+        );
+        assert_eq!(
+            redacted
+                .iter()
+                .find(|(name, _)| name == "content-type")
+                .map(|(_, value)| value),
+            Some(&"text/html".to_owned())
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace ad hoc stdout output in `c1` with structured tracing.
- Redact sensitive response headers before logging them.

## Changes

- Added `tracing` and `tracing-subscriber` to the workspace and `c1` package.
- Initialized tracing with an environment filter and stderr output.
- Switched the example program to emit structured logs for OpenSSL, HTTP, and async output.
- Added header redaction helpers and a unit test for sensitive values.

## Validation

- `cargo check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
