### PR TITLE
Remove the private package classifier from Python metadata

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,9 +6,6 @@ requires-python = ">=3.10"
 authors = [
     { name = "kitsuyui", email = "kitsuyui@kitsuyui.com" },
 ]
-classifiers = [
-    "Private :: Do Not Upload",
-]
 
 [tool.maturin]
 python-source = "pysrc"


### PR DESCRIPTION
## Problem

The Python package metadata still included the obsolete `Private :: Do Not Upload` classifier, which no longer matches the release workflow.

## Change

Removed the private package classifier from `python/pyproject.toml`.

## Verification

- `cd python && uv run poe format`
- `cd python && uv run poe check-all`
- `cd python && uv run poe test`
- `git diff --check`
