### PR TITLE
Add cargo audit to CI dependency checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
 
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a CI job that installs and runs `cargo audit`.
- Fail pull requests when RustSec reports vulnerable crate dependencies.

## Verification
- `actionlint .github/workflows/test.yml`
- `cargo audit`
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`
