### PR TITLE
Strip BiDi override characters in greet() to prevent UI spoofing

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,7 +5,37 @@ extern "C" {
     pub fn alert(s: &str);
 }
 
+/// Displays a greeting alert for `name`.
+///
+/// `name` is sanitized by stripping Unicode bidirectional override characters
+/// (`U+202A`–`U+202E`, `U+2066`–`U+2069`) before display to prevent visual
+/// spoofing in the alert dialog.
 #[wasm_bindgen]
 pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!", name));
+    let safe_name = strip_bidi(name);
+    alert(&format!("Hello, {}!", safe_name));
+}
+
+fn strip_bidi(s: &str) -> String {
+    s.chars()
+        .filter(|c| !matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}'))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_bidi_override_characters() {
+        assert_eq!(strip_bidi("Alice\u{202E}evil"), "Aliceevil");
+        assert_eq!(strip_bidi("\u{2066}hidden"), "hidden");
+        assert_eq!(strip_bidi("normal"), "normal");
+    }
+
+    #[test]
+    fn allows_regular_unicode() {
+        assert_eq!(strip_bidi("こんにちは"), "こんにちは");
+        assert_eq!(strip_bidi("café"), "café");
+    }
 }


### PR DESCRIPTION
## Problem

`greet()` in `wasm/src/lib.rs` passed the caller-supplied `name` argument directly to the JS `alert()` call without any sanitization. Unicode bidirectional override characters (U+202A–U+202E, U+2066–U+2069) in `name` could alter how the alert text is rendered in the browser, enabling visual spoofing attacks where the displayed message appears different from the actual string.

## Fix

Added a `strip_bidi()` helper that filters out characters in the ranges U+202A–U+202E and U+2066–U+2069. `greet()` now passes `name` through `strip_bidi()` before embedding it in the alert message.

**Trade-off:** Filtered characters are silently removed (not escaped or replaced). Silent removal is appropriate here because `alert()` is a display-only context where no fidelity to the raw input is expected, and exposing a placeholder would add noise without benefit.

## Changed file

- `wasm/src/lib.rs`

## Test coverage

Two new unit tests:

- `strips_bidi_override_characters` — verifies that U+202E and U+2066 are removed from input strings.
- `allows_regular_unicode` — verifies that ordinary Unicode (CJK, Latin with diacritics) passes through unchanged.
