### PR TITLE
Sync Python package version with Cargo workspace (0.1.5 → 0.1.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crates.io-LICENSE](https://img.shields.io/crates/l/kitsuyui-rust-playground)](https://github.com/kitsuyui/rust-playground#license)
 ![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/rust-playground/coverage.svg)
 [![type: ignore](https://raw.githubusercontent.com/kitsuyui/rust-playground/gh-counter-assets/badges/type-ignore.svg)](https://github.com/kitsuyui/rust-playground/search?q=%22type%3A+ignore%22+path%3Apython&type=code)
-[![docs.rs](https://img.shields.io/docsrs/kitsuyui-rust-playground-lib)](https://docs.rs/kitsuyui-rust-playground-lib/0.1.5/kitsuyui_rust_playground_lib/)
+[![docs.rs](https://img.shields.io/docsrs/kitsuyui-rust-playground-lib)](https://docs.rs/kitsuyui-rust-playground-lib/latest/kitsuyui_rust_playground_lib/)
 
 ## en: What is this?
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitsuyui_rust_playground"
-version = "0.1.5"
+version = "0.1.8"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "kitsuyui-rust-playground"
-version = "0.1.5"
+version = "0.1.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- `python/pyproject.toml` had `version = "0.1.5"` hardcoded while the Cargo workspace is at `0.1.8`, causing a three-minor-version drift
- `python/Cargo.toml` already uses `version.workspace = true`, so the built wheel carries the correct Cargo version; the pyproject.toml metadata was the stale artifact
- `python/uv.lock` updated to reflect the new pyproject.toml version
- `README.md` docs.rs badge link changed from a hardcoded `0.1.5` path to `/latest/`, so it stays current without manual updates on each release

## Changes

| File | Change |
|------|--------|
| `python/pyproject.toml` | version `0.1.5` → `0.1.8` |
| `python/uv.lock` | editable package version `0.1.5` → `0.1.8` |
| `README.md` | docs.rs link updated to use `/latest/` |

## Verification

No logic changes — only version metadata and badge URL updated. CI will verify the Python build continues to work.