### PR TITLE
ci: enforce coverage threshold

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,6 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: current >= 75%
   paths:
     - coverage.lcov
 codeToTestRatio:


### PR DESCRIPTION
## Summary
- require Octocov coverage reporting to fail below 75%
- keep the threshold below current measured coverage while making regressions visible

## Verification
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo audit`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `actionlint`
- `ruby -e "require \"yaml\"; puts YAML.load_file(\".octocov.yml\").fetch(\"coverage\").fetch(\"acceptable\")"`
- `git diff --check`
