### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ The repository tracks Python `# type: ignore` markers with [`gh-counter`](https:
   - [x] Node.js binding
   - [x] Python binding
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 Licensed under either of

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to run the same checks as CI locally, so formatting and lint
  issues surface before they reach GitHub Actions.
- Documents the setup in `README.md` under a new `## Development` section.
- CI workflows are left completely untouched.

## Changes

- **`lefthook.yml`** (new file): defines two hook stages mirroring `.github/workflows/test.yml`
  - `pre-commit`: `cargo fmt --all -- --check` + `cargo clippy -- -D warnings`
  - `pre-push`: the above plus `cargo test`
- **`README.md`**: adds a `## Development` section (inserted before `## License`) describing
  how to install and use the hooks.

## Verification

All mirrored commands were confirmed to pass on the current `main` before this branch was created:

- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — 12 tests passed, 0 failed

The pre-commit hook fired on commit and passed; the pre-push hook fired on push and passed.

## Notes

- Requires `lefthook` on the developer's PATH (`brew install lefthook` or equivalent).
- Requires `cargo` / a Rust toolchain (already assumed for contributors).
- No changes to CI; GitHub Actions continues to run the full suite as before.
