### PR TITLE
docs: add contributor guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a reproducible problem in rust-playground
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the problem briefly.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+Describe what you expected to happen.
+
+## Actual Behavior
+
+Describe what happened instead.
+
+## Environment
+
+- Operating system:
+- Rust version (`rustc --version`):
+- Cargo version (`cargo --version`):
+- Package, crate, or workspace member:
+
+## Additional Context
+
+Add logs, error messages, or links to a minimal reproduction. Do not include
+secrets, access tokens, private package names, or credentials.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest a focused improvement for rust-playground
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+Describe the requested change briefly.
+
+## Use Case
+
+Explain the problem this would solve or the workflow it would improve.
+
+## Proposed Change
+
+Describe the smallest change that would address the use case.
+
+## Alternatives Considered
+
+List any alternatives or workarounds you considered.
+
+## Additional Context
+
+Add links, examples, or screenshots if they help explain the request. Do not
+include secrets, access tokens, private package names, or credentials.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- TODO
+
+## Checks
+
+- [ ] I kept this pull request focused on one topic.
+- [ ] I updated tests or documentation when behavior changed.
+- [ ] I ran the relevant local checks, or explained why they were not run.
+
+## Local Verification
+
+List the commands you ran, for example:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `cargo check`
+
+## Notes
+
+Mention any remaining risks, follow-up work, or checks that need CI coverage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+Thanks for your interest in improving `rust-playground`.
+
+This is a personal playground for Rust, Python, and WebAssembly packaging
+experiments. Small, focused fixes and documentation improvements are welcome.
+
+## Communication
+
+- Use English for issue titles, pull request titles, and pull request
+  descriptions.
+- Keep each issue or pull request focused on one topic.
+- Do not include secrets, access tokens, private package names, or credentials in
+  issues, pull requests, logs, or screenshots.
+- For larger behavior changes, open an issue first so the scope can be agreed on
+  before implementation.
+
+## Development Setup
+
+Install a current stable Rust toolchain with Cargo. Optional tools are only
+needed when you touch their area:
+
+- `uv` for Python package work under `python/`;
+- `wasm-pack` for WebAssembly package work under `wasm/`;
+- `lefthook` if you want Git hooks that mirror the core CI checks locally.
+
+To install the hooks once:
+
+```sh
+lefthook install
+```
+
+## Local Checks
+
+Run the checks that match your change before opening a pull request. For changes
+to Rust code or shared workspace configuration, run:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+cargo test
+cargo check
+```
+
+If `cargo-audit` is installed, also run:
+
+```sh
+cargo audit
+```
+
+For documentation-only changes, run a spelling check if you have one available
+and make sure Markdown examples stay accurate.
+
+## Issues
+
+Use the issue templates when possible. Bug reports are most useful when they
+include:
+
+- a short summary;
+- steps to reproduce;
+- expected and actual behavior;
+- operating system, Rust version, and package or crate name;
+- relevant logs or error messages.
+
+Feature requests should describe the use case and the smallest change that would
+solve it.
+
+## Pull Requests
+
+Before opening a pull request:
+
+- keep the diff limited to one topic;
+- update tests or documentation when behavior changes;
+- include the local checks you ran;
+- explain any checks you could not run.
+
+CI runs the full suite on pull requests. Passing local checks does not replace CI
+but keeps review focused on the change itself.
+
+## License
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this repository, as defined in the Apache-2.0 license, is dual
+licensed under MIT or Apache-2.0 without additional terms or conditions.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with public issue, pull request, language, license, and local-check expectations.
- Add bug report and feature request issue templates.
- Add a pull request template that asks contributors to list local verification.

## Verification

- `git diff --check`
- `typos CONTRIBUTING.md .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/feature_request.md .github/pull_request_template.md`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo check`
- `cargo audit`

## Notes

- Release packaging, coverage, actionlint, and reusable spellcheck workflows run in GitHub Actions and are not fully reproduced locally for this docs-only change.
