### PR TITLE
Remove --allow-dirty from cargo publish

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -27,10 +27,10 @@ jobs:
         if: github.event_name == 'release' && github.event.release.prerelease
         run: |
           cd c1
-          cargo publish --dry-run --allow-dirty
+          cargo publish --dry-run
           cd -
           cd c2
-          cargo publish --dry-run --allow-dirty
+          cargo publish --dry-run
           cd -
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -39,10 +39,10 @@ jobs:
         if: github.event_name == 'release' && !github.event.release.prerelease
         run: |
           cd c1
-          cargo publish --allow-dirty
+          cargo publish
           cd -
           cd c2
-          cargo publish --allow-dirty
+          cargo publish
           cd -
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `--allow-dirty` from `cargo publish` and `cargo publish --dry-run`
  in `.github/workflows/cratesio-publish.yml`

## Why

`--allow-dirty` bypasses cargo's default check that the working tree is
clean at publish time. In CI the checkout is always clean, so the flag
provides no benefit and masks any accidental dirty-file condition (e.g. a
build artifact unexpectedly placed inside the crate directory).

Removing the flag restores cargo's sanity check: if untracked or modified
files appear in a crate directory at publish time, the workflow will fail
rather than silently including them in the published crate.

## Verification

- `actionlint` — no findings
- `cargo clippy --all-targets --all-features` — 0 warnings/errors

## Trade-offs

If a future step in the same job writes files inside `c1/` or `c2/` before
the publish step, the publish will now fail. This is the correct behaviour;
the fix would be to either remove such steps or explicitly exclude the
generated files from the package via `.cargo/config.toml` or `Cargo.toml`
`exclude`.
