### PR TITLE
ci: add cargo-deny dependency policy check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,17 @@ jobs:
           tool: cargo-audit
       - run: cargo audit
 
+  deny:
+    name: Check dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check licenses bans sources
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -939,18 +939,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -970,13 +970,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ reqwest = { version = "0.13.0", features = ["blocking"] }
 ring = "0.17.8"
 hex = "0.4.3"
 tokio = { version = "1.37.0", features= ["full"] }
-pyo3 = { version = "0.28.0", features = ["extension-module"] }
-pyo3-build-config = "0.28.0"
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
+pyo3-build-config = "0.29.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
Add a root `deny.toml` with cargo-deny policy checks for licenses, dependency bans, and source restrictions. Wire a new `deny` job into `.github/workflows/test.yml` so the policy runs in CI. Update the PyO3 workspace dependency and lockfile to `0.29.0` so the existing audit gate stays green after RustSec advisories on `0.28.3`.

## Changes
- Added `deny.toml` with cargo-deny configuration for licenses, bans, and sources.
- Added a `deny` CI job to `.github/workflows/test.yml` that runs `cargo deny check licenses bans sources`.
- Updated the PyO3 workspace dependency and `Cargo.lock` to `0.29.0`.

## Validation
- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `cargo deny check licenses bans sources` (exit 0; duplicate and wildcard warnings are still reported)
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo audit`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- collateral check clean
- implement-validator overall pass

## Notes
cargo-deny still reports existing duplicate crate and wildcard dependency warnings. They are visible but non-blocking for this change.
