### PR TITLE
docs: document workspace crate roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -939,18 +939,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -970,13 +970,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1012,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ reqwest = { version = "0.13.0", features = ["blocking"] }
 ring = "0.17.8"
 hex = "0.4.3"
 tokio = { version = "1.37.0", features= ["full"] }
-pyo3 = { version = "0.28.0", features = ["extension-module"] }
-pyo3-build-config = "0.28.0"
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
+pyo3-build-config = "0.29.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ The repository tracks Python `# type: ignore` markers with [`gh-counter`](https:
   - [x] Node.js binding
   - [x] Python binding
 
+## Workspace layout
+
+The workspace still contains the historical short crate directories `c1` and
+`c2`. Their roles are:
+
+| Path | Package | Role |
+| --- | --- | --- |
+| `c1/` | `kitsuyui-rust-playground` | Binary crate for CLI and runtime experiments |
+| `c2/` | `kitsuyui-rust-playground-lib` | Library crate published to crates.io |
+| `checkpoint/` | `kitsuyui-rust-playground-checkpoint` | Checkpoint and snapshot experiments |
+| `python/` | Python package workspace | Python binding experiments |
+| `wasm/` | `kitsuyui-rust-playground-wasm` | WebAssembly binding experiments |
+
+Use descriptive directory names for new workspace members. The `c1` and `c2`
+names remain only to avoid churn in existing package paths.
+
 ## Development
 
 This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI


### PR DESCRIPTION
## Summary

- Document the role of each workspace member in `README.md`.
- Explain that `c1/` and `c2/` are historical directory names kept to avoid package path churn.
- Set the expectation that new workspace members should use descriptive directory names.

## Validation

- `typos README.md`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`
- collateral check

`markdownlint-cli2` is not available on the local PATH, and this repository does not define a markdownlint runner.
