### PR TITLE
Handle multiply_sum overflow explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/c2/src/lib.rs
+++ b/c2/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// Adds two unsigned integers.
 ///
 /// # Examples
@@ -10,16 +12,30 @@ pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 
-/// Computes `(a + b) * c` and returns the result as a decimal string.
+/// Error returned when `multiply_sum` overflows the `i64` range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MultiplySumOverflow;
+
+impl fmt::Display for MultiplySumOverflow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(x + y) * factor overflowed the i64 range")
+    }
+}
+
+impl std::error::Error for MultiplySumOverflow {}
+
+/// Computes `(x + y) * factor` and returns the result as a decimal string.
 ///
 /// # Examples
 ///
 /// ```
-/// use kitsuyui_rust_playground_lib::my_calc;
-/// assert_eq!(my_calc(1, 2, 3), "9");
+/// use kitsuyui_rust_playground_lib::multiply_sum;
+/// assert_eq!(multiply_sum(1, 2, 3).unwrap(), "9");
 /// ```
-pub fn my_calc(a: i64, b: i64, c: i64) -> String {
-    ((a + b) * c).to_string()
+pub fn multiply_sum(x: i64, y: i64, factor: i64) -> Result<String, MultiplySumOverflow> {
+    let sum = x.checked_add(y).ok_or(MultiplySumOverflow)?;
+    let product = sum.checked_mul(factor).ok_or(MultiplySumOverflow)?;
+    Ok(product.to_string())
 }
 
 #[cfg(test)]
@@ -33,7 +49,17 @@ mod tests {
     }
 
     #[test]
-    fn test_my_calc() {
-        assert_eq!(my_calc(1, 2, 3), "9");
+    fn test_multiply_sum() {
+        assert_eq!(multiply_sum(1, 2, 3), Ok("9".to_string()));
+    }
+
+    #[test]
+    fn multiply_sum_reports_add_overflow() {
+        assert_eq!(multiply_sum(i64::MAX, 1, 1), Err(MultiplySumOverflow));
+    }
+
+    #[test]
+    fn multiply_sum_reports_multiply_overflow() {
+        assert_eq!(multiply_sum(i64::MAX, 0, 2), Err(MultiplySumOverflow));
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,14 +1,16 @@
 use kitsuyui_rust_playground_lib as kitsuyui_rust_playground;
+use pyo3::exceptions::PyOverflowError;
 use pyo3::prelude::*;
 
 #[pyfunction]
-fn my_calc(a: i64, b: i64, c: i64) -> PyResult<String> {
-    Ok(kitsuyui_rust_playground::my_calc(a, b, c))
+fn multiply_sum(x: i64, y: i64, factor: i64) -> PyResult<String> {
+    kitsuyui_rust_playground::multiply_sum(x, y, factor)
+        .map_err(|error| PyOverflowError::new_err(error.to_string()))
 }
 
 #[pymodule]
 #[pyo3(name = "_native")]
 fn python_kitsuyui_rust_playground(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(my_calc, m)?)?;
+    m.add_function(wrap_pyfunction!(multiply_sum, m)?)?;
     Ok(())
 }

--- a/python/tests/test_kitsuyui_rust_playground.py
+++ b/python/tests/test_kitsuyui_rust_playground.py
@@ -1,9 +1,15 @@
 import kitsuyui_rust_playground as krp
+import pytest
 
 
-def test_my_calc() -> None:
-    assert krp.my_calc(1, 2, 3) == "9"
+def test_multiply_sum() -> None:
+    assert krp.multiply_sum(1, 2, 3) == "9"
+
+
+def test_multiply_sum_overflow_raises_overflow_error() -> None:
+    with pytest.raises(OverflowError):
+        krp.multiply_sum(2**62, 2**62, 1)
 
 
 def test_exports() -> None:
-    assert krp.__all__ == ["my_calc"]
+    assert krp.__all__ == ["multiply_sum"]


### PR DESCRIPTION
## Summary
- use checked i64 arithmetic for multiply_sum and return an explicit Rust error on overflow
- map overflow from the PyO3 wrapper to Python OverflowError and restore the documented multiply_sum export
- refresh quinn-proto in Cargo.lock to 0.11.15 so the dependency audit gate passes

## Validation
- cargo fmt --all
- cargo check
- cargo test
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo build
- cargo audit
- cargo deny check licenses bans sources
- cargo llvm-cov --lcov --output-path coverage.lcov
- cargo build --release --all-features
- uv sync --group dev
- uv run poe check-all
- uv run poe test
- uv run python -c 'from kitsuyui_rust_playground import multiply_sum; ...'
